### PR TITLE
Addition to Update Method (Validity check)

### DIFF
--- a/PSPHPIPAM/Functions/Public/Address/New-PhpIpamAddress.ps1
+++ b/PSPHPIPAM/Functions/Public/Address/New-PhpIpamAddress.ps1
@@ -29,7 +29,7 @@ function New-PhpIpamAddress{
     process{
           $r=Invoke-PhpIpamExecute -method post -controller addresses  -params $params
           if($r -and $r.success){
-            Get-PhpIpamAddress -ID $r.id
+          return  Get-PhpIpamAddress -ID $r.id
           }else{
             Write-Error $r
           }

--- a/PSPHPIPAM/Functions/Public/Address/Update-PhpIpamAddressByID.ps1
+++ b/PSPHPIPAM/Functions/Public/Address/Update-PhpIpamAddressByID.ps1
@@ -19,7 +19,15 @@ function Update-PhpIpamAddress{
     [cmdletBinding()]
     Param(
          [parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,Position=1)]
-         [ValidateScript({$_.ContainsKey("id") -and $_.id})]
+         [ValidateScript({ 
+            if($_ -is [hashtable]){ 
+                if($_.ContainsKey("id")){
+                $True}
+            }elseif($_ -is [psCustomObject]){
+                 if($_.id){
+                 $True}}
+             else{Throw "$_ contains no valid ID"}
+            })]
          $params
     )
 
@@ -29,7 +37,7 @@ function Update-PhpIpamAddress{
     process{
         $r=Invoke-PhpIpamExecute -method patch -controller addresses -identifiers @($params.id) -params $params
         if($r -and $r.success){
-            Get-PhpIpamAddress -ID $params.id
+         return Get-PhpIpamAddress -ID $params.id
         }
     }
 


### PR DESCRIPTION
During working with the script I had some issues.
One of them was that PSObject was okay in NewIPAMAddresse but not in the Update Address method due to the Validation script. I added the posibility to also use PSObject to use as Parameter.

Addionally I return results for some actions to enable verifying if  the action was successfull.

Disclaimer: I am not a trained Powershell developer. This changes were made during testing around. Please feel free to adjust the suggestions.